### PR TITLE
feat: Fix eslint errors

### DIFF
--- a/src/UrlTracker.Backoffice.UI/.eslintrc.cjs
+++ b/src/UrlTracker.Backoffice.UI/.eslintrc.cjs
@@ -8,10 +8,14 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
-  rules: {},
   overrides: [
     {
       files: ['**/*.ts', '**/*.tsx'],
+      rules: {
+        'no-unused-vars': ['off'],
+        '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+        '@typescript-eslint/no-explicit-any': 'warn',
+      },
     },
   ],
 };

--- a/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/sidebars/analyseRecommendation/analyseRecommendation.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/sidebars/analyseRecommendation/analyseRecommendation.lit.ts
@@ -4,7 +4,6 @@ import {
   recommendationsAnalysisServiceContext,
 } from '@/context/recommendationsanalysis.context';
 import { scopeContext } from '@/context/scope.context';
-import { IScope } from '@/models/scope.model';
 import { IRecommendationResponse } from '@/services/recommendation.service';
 import {
   IRecommendationHistoryResponse,

--- a/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/sidebars/explainRecommendations/explainRecommendations.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/sidebars/explainRecommendations/explainRecommendations.lit.ts
@@ -1,5 +1,4 @@
 import { scopeContext } from '@/context/scope.context';
-import { IScope } from '@/models/scope.model';
 import { ensureExists } from '@/util/tools/existancecheck';
 import { consume } from '@lit/context';
 import { LitElement, css, html } from 'lit';

--- a/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/landingpage.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/landingpage.lit.ts
@@ -13,7 +13,6 @@ import {
   IRedirectData,
   IRedirectResponse,
   IRedirectService,
-  ISolvedRecommendationRequest,
 } from '@/services/redirect.service';
 import { ensureServiceExists } from '@/util/tools/existancecheck';
 import variableresourceService from '@/util/tools/variableresource.service';

--- a/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/recommendations.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/recommendations.lit.ts
@@ -4,7 +4,6 @@ import { Ref, createRef, ref } from 'lit/directives/ref.js';
 import recommendationService, {
   IRecommendationCollection,
   IRecommendationResponse,
-  IRecommendationUpdate,
   IRecommendationUpdateBulkRequest,
   IRecommendationsService,
 } from '../../services/recommendation.service';
@@ -18,7 +17,6 @@ import {
   IRedirectData,
   IRedirectResponse,
   IRedirectService,
-  ISolvedRecommendationRequest,
 } from '@/services/redirect.service';
 import variableresourceService from '@/util/tools/variableresource.service';
 import { consume, provide } from '@lit/context';
@@ -269,7 +267,7 @@ export class UrlTrackerRecommendationsTab extends UrlTrackerNotificationWrapper(
     this.selectedItems = this.selectedItems.filter((i) => i !== e.item.id);
   };
 
-  private onSelectAll = (e: any) => {
+  private onSelectAll = (_: any) => {
     if (this.selectedItems.length === this.recommendationCollection?.total) {
       this.selectedItems = [];
     } else {
@@ -277,11 +275,11 @@ export class UrlTrackerRecommendationsTab extends UrlTrackerNotificationWrapper(
     }
   };
 
-  private onClearSelection = (e: any) => {
+  private onClearSelection = (_: any) => {
     this.selectedItems = [];
   };
 
-  private onIgnoreSelection = async (e: any) => {
+  private onIgnoreSelection = async (_: any) => {
     const selectedRecommendations =
       this.recommendationCollection?.results.filter((r) => this.selectedItems.some((i) => i === r.id)) || [];
     const bulkToUpdate: IRecommendationUpdateBulkRequest = selectedRecommendations.map((r) => {

--- a/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/recommendations/recommendationSearch.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/recommendations/recommendationSearch.lit.ts
@@ -31,7 +31,7 @@ export class UrlTrackerRecommendationSearch extends LitElement {
     this._placeholderText = actionsText ?? this._placeholderText;
   }
 
-  private _onSearchInput = (e: UUIInputEvent) => {
+  private _onSearchInput = (_: UUIInputEvent) => {
     this._dispatchSearch(this.inputRef.value?.shadowRoot?.querySelector('input')?.value ?? '');
   };
 

--- a/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/recommendations/recommendationTag/recommendationTag.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/recommendations/recommendationTag/recommendationTag.lit.ts
@@ -1,5 +1,5 @@
-import { LitElement, css, html, nothing, unsafeCSS } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { LitElement, css, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { consume } from '@lit/context';
 import { ILocalizationService, localizationServiceContext } from '../../../../context/localizationservice.context';
 import { styleMap } from 'lit/directives/style-map.js';

--- a/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/redirects.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/redirects.lit.ts
@@ -203,7 +203,7 @@ export class UrlTrackerRedirectTab extends UrlTrackerNotificationWrapper(LitElem
     this.openInspectPanel(e.detail);
   };
 
-  private onAddRedirect = (e: any) => {
+  private onAddRedirect = (_: any) => {
     this.openNewRedirectPanel();
   };
 
@@ -242,7 +242,7 @@ export class UrlTrackerRedirectTab extends UrlTrackerNotificationWrapper(LitElem
     this.selectedItems = this.selectedItems.filter((i) => i !== e.item.id);
   };
 
-  private onSelectAll = (e: any) => {
+  private onSelectAll = (_: any) => {
     if (this.selectedItems.length === this.redirectCollection?.total) {
       this.selectedItems = [];
     } else {
@@ -250,15 +250,15 @@ export class UrlTrackerRedirectTab extends UrlTrackerNotificationWrapper(LitElem
     }
   };
 
-  private onClearSelection = (e: any) => {
+  private onClearSelection = (_: any) => {
     this.selectedItems = [];
   };
 
-  private onConvertSelection = async (e: any) => {
+  private onConvertSelection = async (_: any) => {
     const selectedRedirects =
       this.redirectCollection?.results.filter((r) => this.selectedItems.some((i) => i === r.id)) || [];
     const bulkToUpdate = selectedRedirects.map((r) => {
-      const { id, key, additionalData, createDate, updateDate, ...data } = r;
+      const { id: _, key: __, additionalData: ___, createDate: ____, updateDate: _____, ...data } = r;
       return {
         id: r.id,
         data: data,
@@ -273,7 +273,7 @@ export class UrlTrackerRedirectTab extends UrlTrackerNotificationWrapper(LitElem
     this.search();
   };
 
-  private onDeleteSelection = async (e: any) => {
+  private onDeleteSelection = async (_: any) => {
     const selectedRedirects =
       this.redirectCollection?.results.filter((r) => this.selectedItems.some((i) => i === r.id)) || [];
     const bulkToDelete = selectedRedirects.map((r) => r.id);

--- a/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/redirects/redirectsSearch.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/redirects/redirectsSearch.lit.ts
@@ -32,7 +32,7 @@ export class UrlTrackerRedirectsSearch extends LitElement {
     this._placeholderText = actionsText ?? this._placeholderText;
   }
 
-  private _onSearchInput = (e: UUIInputEvent) => {
+  private _onSearchInput = (_: UUIInputEvent) => {
     this._dispatchSearch(this.inputRef.value?.shadowRoot?.querySelector('input')?.value ?? '');
   };
 

--- a/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/redirects/target/implementations/contenttarget.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/dashboard/tabs/redirects/target/implementations/contenttarget.lit.ts
@@ -64,7 +64,7 @@ export class UrlTrackerContentRedirectTarget extends baseType {
       if (!this.contentItem) {
         this.errorText = await this.localizationService?.localize('urlTrackerRedirectTarget_contenterror');
       }
-      const [id, culture] = this.redirect.target.value.split(';');
+      const [id] = this.redirect.target.value.split(';');
       this.contentId = id;
     } else {
       await this.init();

--- a/src/UrlTracker.Backoffice.UI/frontend/js/services/recommendationanalysis.service.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/services/recommendationanalysis.service.ts
@@ -1,7 +1,6 @@
 import { Axios } from 'axios';
 import { axiosInstance } from '../util/tools/axios.service';
 import urlresource, { IControllerUrlResource, IUrlResource } from '../util/tools/urlresource.service';
-import { IRecommendationResponse } from './recommendation.service';
 
 export interface IRecommendationHistoryResponse {
   firstOccurance: string;

--- a/src/UrlTracker.Backoffice.UI/frontend/js/umbraco/editor.service.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/umbraco/editor.service.ts
@@ -1,5 +1,5 @@
 // based on https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.services.editorService
-export interface IEditorService<T extends any> {
+export interface IEditorService<T> {
   contentEditor(editor: IContentEditor): void;
   close: () => void;
   closeAll: () => void;
@@ -38,8 +38,8 @@ export interface IContent {
 export interface IContentEditor {
   id: string;
   create: boolean;
-  submit: Function;
-  close: Function;
+  submit: () => Promise<void>;
+  close: () => Promise<void>;
   parentId: string;
   documentTypeAlias: string;
   allowSaveAndClose: boolean;

--- a/src/UrlTracker.Backoffice.UI/frontend/js/umbraco/overlay.service.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/umbraco/overlay.service.ts
@@ -8,6 +8,8 @@ interface IConfirmDeleteOverlay {
   confirmMessageStyle?: string;
   submitButtonStyle?: string;
   submitButtonLabelKey?: string;
+  // eslint-disable-next-line @typescript-eslint/ban-types
   close?: Function;
+  // eslint-disable-next-line @typescript-eslint/ban-types
   submit?: Function;
 }

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/inputs/redirectImport.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/inputs/redirectImport.lit.ts
@@ -51,9 +51,9 @@ export class UrlTrackerRedirectImport extends LitElement {
     return html`<div class="body">
       <p>
         Drop a csv file in the box below to import redirects.
-        <a @click=${this.handleDownloadTemplate}
+        <button @click=${this.handleDownloadTemplate}
           >You can download a template here <uui-icon name="icon-help-alt"></uui-icon
-        ></a>
+        ></button>
       </p>
       <uui-file-dropzone id="browse-dropzone" label="Drag / drop a file here" accept="csv" @change=${this.handleChange}>
         Drag / drop a file here
@@ -77,15 +77,33 @@ export class UrlTrackerRedirectImport extends LitElement {
       margin-top: 0;
     }
 
-    a,
-    a:visited,
-    a:active {
-      color: black;
-      text-decoration: none;
+    button {
+      /* Reset button */
+      border: none;
+      margin: 0;
+      padding: 0;
+      width: auto;
+      overflow: visible;
+      background: transparent;
+
+      /* inherit font & color from ancestor */
+      color: inherit;
+      font: inherit;
+
+      /* Normalize line-height. Cannot be changed from normal in Firefox 4+. */
+      line-height: normal;
+
+      /* Corrects font smoothing for webkit */
+      -webkit-font-smoothing: inherit;
+      -moz-osx-font-smoothing: inherit;
+
+      /* Corrects inability to style clickable input types in iOS */
+      -webkit-appearance: none;
+      
       cursor: pointer;
     }
 
-    a:hover {
+    button:hover {
       text-decoration: underline;
     }
 

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectForce.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectForce.lit.ts
@@ -37,7 +37,7 @@ export class UrlTrackerRedirectForce extends LitElement {
     this._infoText = text ?? 'fallback';
   };
 
-  private _onToggleChange = (e: any) => {
+  private _onToggleChange = (_: any) => {
     this.force = !this.force;
 
     this.dispatchEvent(

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectIncomingUrl.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectIncomingUrl.lit.ts
@@ -90,7 +90,7 @@ export class UrlTrackerRedirectIncomingUrl extends LitElement {
     }));
   };
 
-  private onInput = (e: UUIInputEvent) => {
+  private onInput = (_: UUIInputEvent) => {
     this.incomingUrl = this.inputRef.value?.shadowRoot?.querySelector('input')?.value ?? '';
     this.dispatchEvent(
       new CustomEvent('input', {
@@ -103,7 +103,7 @@ export class UrlTrackerRedirectIncomingUrl extends LitElement {
 
   private _debouncedOnInput = debounce(this.onInput, 500);
 
-  private onTypeChange = (item: ITypeButton, e: Event) => {
+  private onTypeChange = (item: ITypeButton, _: Event) => {
     this._selectedType = item;
     this.dispatchEvent(
       new CustomEvent('typechange', {

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectOutgoingUrl.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectOutgoingUrl.lit.ts
@@ -87,7 +87,9 @@ export class UrlTrackerRedirectOutgoingUrl extends LitElement {
 
     switch (this.outgoingStrategy) {
       case variableresourceService.get<ITargetStrategies>('redirectTargetStrategies').content:
+        // eslint-disable-next-line no-case-declarations
         const [id, culture] = this.outgoingUrl.split(';');
+        // eslint-disable-next-line no-case-declarations
         const intId = Number.parseInt(id, 10);
 
         if (!isNaN(intId)) {
@@ -169,7 +171,7 @@ export class UrlTrackerRedirectOutgoingUrl extends LitElement {
     );
   };
 
-  private onInput = (e?: UUIInputEvent) => {
+  private onInput = (_?: UUIInputEvent) => {
     this.dispatchEvent(
       new CustomEvent('input', {
         detail: this.inputRef.value?.shadowRoot?.querySelector('input')?.value ?? '',
@@ -181,7 +183,7 @@ export class UrlTrackerRedirectOutgoingUrl extends LitElement {
 
   private _debouncedOnInput = debounce(this.onInput, 500);
 
-  private onTypeChange = (item: ITypeButton, e: Event) => {
+  private onTypeChange = (item: ITypeButton, _: Event) => {
     this._selectedType = item;
 
     this.dispatchEvent(

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectPermanent.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectPermanent.lit.ts
@@ -37,7 +37,7 @@ export class UrlTrackerRedirectPermanent extends LitElement {
     this._infoText = text ?? 'fallback';
   };
 
-  private _onToggleChange = (e: any) => {
+  private _onToggleChange = (_: any) => {
     this.isPermanent = !this.isPermanent;
 
     this.dispatchEvent(

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectPreserveQuerystring.lit.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/elements/redirects/simpleRedirect/redirectPreserveQuerystring.lit.ts
@@ -37,7 +37,7 @@ export class UrlTrackerRedirectPreserveQuerystring extends LitElement {
     this._infoText = text ?? 'fallback';
   };
 
-  private _onToggleChange = (e: any) => {
+  private _onToggleChange = (_: any) => {
     this.preserve = !this.preserve;
 
     this.dispatchEvent(

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/functions/debounce.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/functions/debounce.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-types
 export const debounce = (fn: Function, ms = 300) => {
   let timeoutId: ReturnType<typeof setTimeout>;
   return function (this: any, ...args: any[]) {

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/tools/builder/tabBuilder.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/tools/builder/tabBuilder.ts
@@ -2,7 +2,7 @@ import { TemplateResult } from 'lit';
 import TabStrategy from '../../../dashboard/tab';
 
 export class TabBuilder {
-  public addTab(alias: string, template: TemplateResult) {
+  public addTab(alias: string, _: TemplateResult) {
     console.log('public acces test');
     console.log(this._checkTabNameUnqiue(alias));
   }

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/tools/existancecheck.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/tools/existancecheck.ts
@@ -1,10 +1,10 @@
-export function ensureExists<T extends {}>(
+export function ensureExists<T extends object>(
   obj: T | undefined,
   msg: string = 'Required object is undefined',
 ): asserts obj is T {
   if (!obj) throw Error(msg);
 }
 
-export function ensureServiceExists<T extends {}>(obj: T | undefined, service: string): asserts obj is T {
+export function ensureServiceExists<T extends object>(obj: T | undefined, service: string): asserts obj is T {
   ensureExists(obj, `This element requires an instance of ${service}`);
 }

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/tools/urlresource.service.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/tools/urlresource.service.ts
@@ -78,7 +78,7 @@ class ControllerUrlResource implements IControllerUrlResource {
      * - Does not contain any other characters
      */
     if (!rawEndpoint.startsWith('/')) throw new Error('The endpoint does not start with a forward slash');
-    if (!/^\/[\w\{\}\/]+$/.test(rawEndpoint)) throw new Error('The endpoint does not conform to the expected pattern');
+    if (!/^\/[\w{}/]+$/.test(rawEndpoint)) throw new Error('The endpoint does not conform to the expected pattern');
   }
 
   private createFactoryFromComponents(

--- a/src/UrlTracker.Backoffice.UI/frontend/js/util/tools/versionprovider.service.ts
+++ b/src/UrlTracker.Backoffice.UI/frontend/js/util/tools/versionprovider.service.ts
@@ -1,5 +1,4 @@
 import variableResource, { IVariableResource } from './variableresource.service';
-import { IUrlTrackerVariables } from './versionproviderservice.constants';
 
 export interface IVersionProvider {
   get version(): string;


### PR DESCRIPTION
## Proposed changes
- Fixes Eslint errors in the UI project.
  - Sets rules for `no-unused-vars` to align with the coding style found in the project (Use `_` for unused vars and args)
  - Lower uses of `any` to warn as there's about 40 places that uses `any`
- Removes unused imports and variables.
- Changes the anchor tag to a button on the redirects import as this triggered an `a11y` error and fixed the CSS for the use of `button`.
![image](https://github.com/Infocaster/UrlTracker/assets/24605285/04fba00d-9990-412a-8f2b-90555345d523)

This is now the result of `npm run lint`:
![image](https://github.com/Infocaster/UrlTracker/assets/24605285/dcd1423d-9dd4-4ab9-aac5-e2f52a407ddb)


***
@Infocaster/developers
