### PR TITLE
i-201 Invalid column name 'totalOccurrences' when loading dashboard

### DIFF
--- a/src/UrlTracker.Core/Database/ClientErrorRepository.cs
+++ b/src/UrlTracker.Core/Database/ClientErrorRepository.cs
@@ -66,31 +66,34 @@ namespace UrlTracker.Core.Database
             }
 
             Task<int> totalRecordsTask = Database.ExecuteScalarAsync<int>(countQuery);
-
+            
             var aggregateQuery = Sql()
                 .Select<ClientError2ReferrerDto>(e => e.ClientError)
-                .AndSelectCount(Defaults.DatabaseSchema.AggregateColumns.TotalOccurrences)
-                .AndSelectMax<ClientError2ReferrerDto>(Defaults.DatabaseSchema.AggregateColumns.MostRecentOccurrence, null, e => e.CreateDate)
+                .AndSelectCount(Defaults.DatabaseSchema.AggregateColumns.TotalOccurrences) 
+                .AndSelectMax<ClientError2ReferrerDto>(Defaults.DatabaseSchema.AggregateColumns.MostRecentOccurrence,null,e => e.CreateDate)
                 .From<ClientError2ReferrerDto>()
-                .GroupBy<ClientError2ReferrerDto>(e => e.ClientError)
-                ;
-
+                .GroupBy<ClientError2ReferrerDto>(e => e.ClientError);
+            
             var selectQuery = Sql()
-                .Select<ClientErrorDto>("c")
+                .Select<ClientErrorDto>("c")  // main table columns
+                .AndSelect("cr." + SqlSyntax.GetQuotedColumnName(Defaults.DatabaseSchema.AggregateColumns.TotalOccurrences))
+                .AndSelect("cr." + SqlSyntax.GetQuotedColumnName(Defaults.DatabaseSchema.AggregateColumns.MostRecentOccurrence))
                 .From<ClientErrorDto>("c")
-                .LeftJoin(aggregateQuery, "cr").On<ClientError2ReferrerDto, ClientErrorDto>((l, r) => l.ClientError == r.Id, "cr", "c")
+                .LeftJoin(aggregateQuery, "cr")
+                .On<ClientError2ReferrerDto, ClientErrorDto>((l, r) => l.ClientError == r.Id, "cr", "c")
                 .Where<ClientErrorDto>(e => e.Ignored == false, "c");
+            
             if (query != null)
             {
                 selectQuery.Where<ClientErrorDto>(e => e.Url.Contains(query), "c");
             }
-
+            
             string orderParameter;
             switch (order)
             {
                 case OrderBy.LastOccurrence:
-                case OrderBy.Created: orderParameter = SqlSyntax.GetQuotedColumnName(Defaults.DatabaseSchema.AggregateColumns.MostRecentOccurrence); break;
-                case OrderBy.Occurrences: orderParameter = SqlSyntax.GetQuotedColumnName(Defaults.DatabaseSchema.AggregateColumns.TotalOccurrences); break;
+                case OrderBy.Created: orderParameter = "cr." + SqlSyntax.GetQuotedColumnName(Defaults.DatabaseSchema.AggregateColumns.MostRecentOccurrence); break;
+                case OrderBy.Occurrences: orderParameter = "cr." + SqlSyntax.GetQuotedColumnName(Defaults.DatabaseSchema.AggregateColumns.TotalOccurrences); break;
                 default: throw new ArgumentOutOfRangeException(nameof(order));
             }
 

--- a/src/UrlTracker.Core/Database/Dtos/ClientErrorMetaDataDto.cs
+++ b/src/UrlTracker.Core/Database/Dtos/ClientErrorMetaDataDto.cs
@@ -8,7 +8,7 @@ namespace UrlTracker.Core.Database.Dtos
     public class ClientErrorMetaDataDto
     {
         [Column(Defaults.DatabaseSchema.AggregateColumns.TotalOccurrences)]
-        public int? TotalOccurrances { get; set; }
+        public int? TotalOccurrences { get; set; }
 
         [Column(Defaults.DatabaseSchema.AggregateColumns.MostCommonReferrer)]
         public string MostCommonReferrer { get; set; }

--- a/src/UrlTracker.Core/Database/Entities/ClientErrorMetaData.cs
+++ b/src/UrlTracker.Core/Database/Entities/ClientErrorMetaData.cs
@@ -6,7 +6,7 @@ namespace UrlTracker.Core.Database.Entities
     {
         string MostCommonReferrer { get; }
         DateTime? MostRecentOccurrance { get; }
-        int? TotalOccurrances { get; }
+        int? TotalOccurrences { get; }
         int ClientError { get; }
     }
     public class ClientErrorMetaData
@@ -16,7 +16,7 @@ namespace UrlTracker.Core.Database.Entities
 
         public DateTime? MostRecentOccurrance { get; set; }
 
-        public int? TotalOccurrances { get; set; }
+        public int? TotalOccurrences { get; set; }
 
         public int ClientError { get; set; }
     }

--- a/src/UrlTracker.Core/Database/Factories/ClientErrorFactory.cs
+++ b/src/UrlTracker.Core/Database/Factories/ClientErrorFactory.cs
@@ -86,7 +86,7 @@ namespace UrlTracker.Core.Database.Factories
         {
             var entity = new ClientErrorMetaData
             {
-                TotalOccurrances = dto.TotalOccurrances,
+                TotalOccurrences = dto.TotalOccurrences,
                 MostCommonReferrer = dto.MostCommonReferrer,
                 MostRecentOccurrance = dto.MostRecentOccurrance,
                 ClientError = dto.ClientError

--- a/src/UrlTracker.Core/Defaults/Defaults_DatabaseSchema.cs
+++ b/src/UrlTracker.Core/Defaults/Defaults_DatabaseSchema.cs
@@ -19,7 +19,7 @@ namespace UrlTracker.Core
 
             public static class AggregateColumns
             {
-                public const string TotalOccurrences = "totalOccurrances";
+                public const string TotalOccurrences = "totalOccurrences";
                 public const string MostRecentOccurrence = "mostRecentOccurrence";
                 public const string MostCommonReferrer = "mostCommonReferrer";
             }

--- a/src/UrlTracker.Core/Models/ClientError.cs
+++ b/src/UrlTracker.Core/Models/ClientError.cs
@@ -22,7 +22,7 @@ namespace UrlTracker.Core.Models
             {
                 LatestOccurrence = metaData.MostRecentOccurrance ?? default;
                 MostCommonReferrer = metaData.MostCommonReferrer;
-                Occurrences = metaData.TotalOccurrances ?? default;
+                Occurrences = metaData.TotalOccurrences ?? default;
             }
         }
 


### PR DESCRIPTION
Fix: Invalid column name 'mostRecentOccurrence' and 'totalOccurrances '.  when loading dashboard
Fix: renamed spelling error TotalOccurrances to TotalOccurrences

## Related issue
https://github.com/Infocaster/UrlTracker/issues/201

## Proposed changes
renamed spelling error TotalOccurrances to TotalOccurrences

This appears to be a SQL pattern issue where aggregate columns from subqueries need to be explicitly selected in the outer query to be available for ordering. The error occurs because the ORM generates SQL that references columns not included in the SELECT clause.

***
@Infocaster/developers
