### PR TITLE
 Fix: load UrlTracker dashboard only on Content section Added conditions in umbraco package to load the dashboard only on Con…

### DIFF
--- a/src/UrlTracker.Backoffice.UI/frontend/public/umbraco-package.json
+++ b/src/UrlTracker.Backoffice.UI/frontend/public/umbraco-package.json
@@ -11,7 +11,13 @@
       "meta": {
         "label": "Url Tracker",
         "pathname": "urltracker"
-      }
+      },
+      "conditions": [
+        {
+          "alias": "Umb.Condition.SectionAlias",
+          "match": "Umb.Section.Content"
+        }
+      ]
     },
     {
       "type": "backofficeEntryPoint",


### PR DESCRIPTION
## Related issue
 The UrlTracker dashboard was appearing in all Umbraco backoffice sections. This fix adds a section condition to the umbraco-package.json so the dashboard is only loaded when the user is in the Content section.                                 
   
## Changes:                                                                                                                                                                                                                                          
  - Added Umb.Condition.SectionAlias condition with Umb.Section.Content to the dashboard entry in umbraco-package.json      


***
@Infocaster/developers
