### PR TITLE
Added M202608151200_RecommendationUrlColumnLength.cs — alters urltrackerRecommendation.url to NVARCHAR(2083), skipping SQLite (no explicit lengths there), following the same isolated-migration convention as the existing fix.

### DIFF
--- a/src/UrlTracker.Core/Database/Migrations/M202608151200_RecommendationUrlColumnLength.cs
+++ b/src/UrlTracker.Core/Database/Migrations/M202608151200_RecommendationUrlColumnLength.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+using NPoco.DatabaseTypes;
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace UrlTracker.Core.Database.Migrations
+{
+    // REMINDER: Migration code is ALWAYS isolated. Do not reuse constants from shared code. Existing migrations should never change, unless they're broken.
+    [ExcludeFromCodeCoverage]
+    internal class M202608151200_RecommendationUrlColumnLength : MigrationBase
+    {
+        private const int _urlMaxLength = 2083;
+        private const string _recommendationTableName = "urltrackerRecommendation";
+        private const string _urlColumn = "url";
+
+        public M202608151200_RecommendationUrlColumnLength(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        protected override void Migrate()
+        {
+            // SQLite doesn't need this upgrade
+            if (DatabaseType is SQLiteDatabaseType) return;
+
+            // M202312101755_UrlColumnLength widened the url columns on ClientError, Redirect and Referrer to fit long
+            // URLs (e.g. with Google Ads tracking parameters), but missed the Recommendation table, which is populated
+            // from the same client error data and therefore needs the same column length.
+            Alter.Table(_recommendationTableName).AlterColumn(_urlColumn).AsString(_urlMaxLength).NotNullable().Do();
+        }
+    }
+}

--- a/src/UrlTracker.Core/Database/Migrations/MigrationPlanFactory.cs
+++ b/src/UrlTracker.Core/Database/Migrations/MigrationPlanFactory.cs
@@ -19,7 +19,8 @@ namespace UrlTracker.Core.Database.Migrations
                 .To<M202212111209_PopulateRedactionScores>("3.1")
                 .To<M202406061746_PatchSqlite>("3.2")
                 .To<M202407260819_PostMigrationCorrectValueLength>("3.3")
-                .To<M202407261301_AddAdvancedFlag>("3.4");
+                .To<M202407261301_AddAdvancedFlag>("3.4")
+                .To<M202608151200_RecommendationUrlColumnLength>("3.5");
             // Use ☝️ this path for new migrations
 
             result.From("urlTracker") // support for older db and long route if the url tracker had already been used before


### PR DESCRIPTION
Registered it as step 3.5 in MigrationPlanFactory.cs after