### PR TITLE
#i-243 Fix ArgumentOutOfRangeException on Recommendation Analysis referrers endpoint

### DIFF
--- a/src/UrlTracker.Core/Database/ClientErrorRepository.cs
+++ b/src/UrlTracker.Core/Database/ClientErrorRepository.cs
@@ -214,7 +214,7 @@ namespace UrlTracker.Core.Database
                .LeftJoin<ReferrerDto>(_referrerTableAlias)
                .On<ClientError2ReferrerDto, ReferrerDto>((l, r) => l.Referrer == r.Id, _mostCommonReferrerTableAlias, _referrerTableAlias);
 
-            sql.Where<ClientError2ReferrerDto>(e => clientErrors.Contains(e.ClientError), _occurrancesTableAlias)
+            sql.WhereIn<ClientError2ReferrerDto>(e => e.ClientError, clientErrors, _occurrancesTableAlias)
                .GroupBy<ClientError2ReferrerDto>(_occurrancesTableAlias, e => e.ClientError)
                .Append($", {SqlSyntax.GetQuotedTableName(_referrerTableAlias)}.{SqlSyntax.GetQuotedTableName("url")}");
 


### PR DESCRIPTION
Fix ArgumentOutOfRangeException on Recommendation Analysis referrers endpoint

## Related issue
GET /umbraco/management/api/v1/UrlTracker/RecommendationAnalysis/{id}/referrers (the backoffice "Recommendation Analysis" screen) throws an unhandled ArgumentOutOfRangeException instead of returning the most-common-referrer data.

## Proposed changes
Replace: ClientErrorRepository.cs:217
sql.Where<ClientError2ReferrerDto>(e => clientErrors.Contains(e.ClientError), _occurrancesTableAlias)
with:
sql.WhereIn<ClientError2ReferrerDto>(e => e.ClientError, clientErrors, _occurrancesTableAlias)
***
@Infocaster/developers
